### PR TITLE
Fix README (there was a mention of C++ instead of Rust)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ language: Rust
 # edjsamples-rust
 This repository contains EDJX's sample serverless functions written in Rust. Each sample also contains a README, which has a detailed explanation of the specifics of the Serverless Function. These sample functions can be deployed to the EDJX network using EDJX CLI. More details on how to deploy can be found [in the EDJX Documentation](https://docs.edjx.io/docs/latest/how_tos/cli_build_wasm_file.html).
 
-It is also possible to build C++ applications into WASM executables manually using the steps below.
+It is also possible to build Rust applications into WASM executables manually using the steps below.
 
 ## Directory Structure
 


### PR DESCRIPTION
There was an accidental mention of C++ in the readme.